### PR TITLE
Feat/apartments new

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'pry-rails'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.0)
     puma (3.12.6)
     racc (1.6.0)
@@ -225,6 +227,7 @@ DEPENDENCIES
   orderly
   pg (>= 0.18, < 2.0)
   pry
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.8, >= 5.2.8.1)
   rspec-rails

--- a/app/views/apartments/index.html.erb
+++ b/app/views/apartments/index.html.erb
@@ -1,4 +1,5 @@
 <p><a href="/tenants">Tenant List</a></p>
+<p><a href="/apartments/new">New Apartment</a></p>
 <h1>Apartments List</h1>
 
 <% @apartments.each do |apartment| %>

--- a/app/views/apartments/new.html.erb
+++ b/app/views/apartments/new.html.erb
@@ -1,7 +1,3 @@
-<ul>
-  <li><a href="/apartments">Apartment List</a></li>
-  <li><a href="/tenants">Tenant List</a></li>
-</ul>
 <form action="/apartments" method="post">
   <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
   <p><h1>Create a new apartment:</h1></p>
@@ -34,3 +30,7 @@
   <input type='submit'/>
 </form>
 
+<ul>
+  <li><a href="/apartments">Apartment List</a></li>
+  <li><a href="/tenants">Tenant List</a></li>
+</ul>

--- a/app/views/apartments/new.html.erb
+++ b/app/views/apartments/new.html.erb
@@ -27,7 +27,7 @@
   <input type="radio" id="petno" name="apartment[pet_friendly]" value="No">
   <label for="petno">No</label><br>
 
-  <input type='submit'/>
+  <input type='submit' value= 'Submit'/>
 </form>
 
 <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,13 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/', to: 'welcome#index'
   get '/apartments', to: 'apartments#index'
-  get '/apartments/:id', to: 'apartments#show'
   get '/apartments/new', to: 'apartments#new'
+
+  get '/apartments/:id', to: 'apartments#show'
   post '/apartments', to: 'apartments#create'
 
   get '/tenants', to: 'tenants#index'
   get '/tenants/:id', to: 'tenants#show'
   get '/apartments/:apartment_id/tenants', to: 'apartment_tenants#index'
-  
 
 end

--- a/spec/features/apartments/index_spec.rb
+++ b/spec/features/apartments/index_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe 'apartments index page', type: :feature do
         expect(page).to have_content(@apartment_3.created_at)
 
       end
+
+      it 'A link takes me to a form to fill out to enter a new apartment and its attributes' do 
+        visit '/apartments'
+        click_on('New Apartment')
+        expect(current_path).to eq("/apartments/new")
+
+
+      end
     end
 
   end

--- a/spec/features/apartments/new_spec.rb
+++ b/spec/features/apartments/new_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe 'apartments new page', type: :feature do
       it 'i see a form to create a new record' do 
         visit '/apartments/new'
         expect(page).to have_content('Apartment Name:')
+        expect(page).to have_content('Washer and Dryer In-Unit?')
+        expect(page).to have_content('City:')
+        expect(page).to have_content('State')
+        expect(page).to have_content('Pet Friendly?')
+
+
 
       end
 
@@ -43,7 +49,6 @@ RSpec.describe 'apartments new page', type: :feature do
 
         it 'can be redirected to apartments page where the user can see the new record' do 
           visit '/apartments'
-          save_and_open_page
           expect(page).to have_content('Haunted House')
         end        
       end 

--- a/spec/features/apartments/new_spec.rb
+++ b/spec/features/apartments/new_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'apartments new page', type: :feature do 
+  describe 'as a visitor' do 
+    describe 'when i visit /apartments/new' do 
+      it 'i see a form to create a new record' do 
+        visit '/apartments/new'
+        expect(page).to have_content('Apartment Name:')
+
+      end
+
+
+      describe 'i can add an apartment with attributes and submit to /apartments' do 
+        # apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
+        # apartment_2 = Apartment.create!(apt_name: "Cruze Apartments", has_wd: true, unit_count: 50, city: "Denver", state: "CO", pet_friendly: true)
+        # apartment_3 = Apartment.create!(apt_name: "The Walter", has_wd: false, unit_count: 35, city: "Aurora", state: "CO", pet_friendly: false)
+        # visit '/apartments/new'
+        # fill_in 'apartment[apt_name]', with: 'Haunted House'
+        # choose 'wdno' 
+        # fill_in 'apartment[unit_count]', with: 180
+        # fill_in 'apartment[city]', with: 'Fear Town'
+        # fill_in 'apartment[state]', with: 'CA' 
+        # choose 'petyes'
+        before :each do 
+          @apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
+          @apartment_2 = Apartment.create!(apt_name: "Cruze Apartments", has_wd: true, unit_count: 50, city: "Denver", state: "CO", pet_friendly: true)
+          @apartment_3 = Apartment.create!(apt_name: "The Walter", has_wd: false, unit_count: 35, city: "Aurora", state: "CO", pet_friendly: false)
+          visit '/apartments/new'
+          fill_in 'apartment[apt_name]', with: 'Haunted House'
+          choose 'wdno' 
+          fill_in 'apartment[unit_count]', with: 180
+          fill_in 'apartment[city]', with: 'Fear Town'
+          fill_in 'apartment[state]', with: 'CA' 
+          choose 'petyes'
+          click_button 'Submit'
+
+        end
+
+        it 'can enter a new record and hit submit' do 
+          expect(current_path).to eq("/apartments")
+          save_and_open_page
+        end
+
+        it 'can be redirected to apartments page where the user can see the new record' do 
+          visit '/apartments'
+          save_and_open_page
+          expect(page).to have_content('Haunted House')
+        end        
+      end 
+    end
+  end
+end


### PR DESCRIPTION
Added a form and testing to add a new apartment to the apartments table.  After filling out the new apartment form and clicking submit, the user is directed back to the apartments index page where that new apartment is listed. All of these new features have been tested in the new_spec file for apartments. 