### PR TITLE
Feat/apartments update

### DIFF
--- a/app/controllers/apartments_controller.rb
+++ b/app/controllers/apartments_controller.rb
@@ -29,4 +29,24 @@ class ApartmentsController < ApplicationController
     @apartment = Apartment.find(params[:id])
   end
 
+  def edit 
+    @apartment = Apartment.find(params[:id])
+  end
+
+  def update 
+    apartment = Apartment.find(params[:id])
+    apartment.update({
+      apt_name: params[:apartment][:apt_name],
+      has_wd: params[:apartment][:has_wd],
+      unit_count: params[:apartment][:unit_count],
+      city: params[:apartment][:city],
+      state: params[:apartment][:state],
+      pet_friendly: params[:apartment][:pet_friendly],
+    })
+    apartment.save 
+    redirect_to "/apartments/#{apartment.id}"
+
+  end
+
+
 end

--- a/app/views/apartments/edit.html.erb
+++ b/app/views/apartments/edit.html.erb
@@ -1,0 +1,41 @@
+<form action = "/apartments/<%= @apartment.id %>" method = "post">
+  <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token%>">
+  <input type="hidden" name="_method" value="PATCH" />
+
+  <h1>Edit <%= @apartment.apt_name %></h1>
+  <p>Washer/Dryer In-Unit? <%= @apartment.has_wd %></p>
+  <p>Total Units: <%= @apartment.unit_count %></p>
+  <p>City: <%= @apartment.city %></p>
+  <p>State: <%= @apartment.state %></p>
+  <p>Pet Friendly? <%= @apartment.pet_friendly %></p>
+  <p>Tenants: <%= @apartment.tenants.length %></p><br/>
+
+  <label for='apartment[apt_name]'>Apartment Name:</label><br>
+  <input type='text' name='apartment[apt_name]'/><br/>
+
+ 
+  <label for='apartment[has_wd]'>Washer and Dryer In-Unit?</label><br>
+  <input type="radio" id="wdyes" name="apartment[has_wd]" value="Yes">
+  <label for="wdyes">Yes</label><br>
+  <input type="radio" id="wdno" name="apartment[has_wd]" value="No">
+  <label for="wdno">No</label><br>
+
+  <label for='apartment[unit_count]'>How many units?</label><br>
+  <input type='number' name='apartment[unit_count]'/><br/>
+
+  <label for='apartment[city]'>City:</label><br>
+  <input type='text' name='apartment[city]'/><br/>
+
+  <label for='apartment[state]'>State:</label><br>
+  <input type='text' name='apartment[state]'/><br/>
+
+  <label for='apartment[pet_friendly]'>Pet Friendly?</label><br>
+  <input type="radio" id="petyes" name="apartment[pet_friendly]" value="Yes">
+  <label for="petyes">Yes</label><br>
+  <input type="radio" id="petno" name="apartment[pet_friendly]" value="No">
+  <label for="petno">No</label><br>
+
+  <input type='submit' value= 'Submit'/>
+</form>
+
+

--- a/app/views/apartments/show.html.erb
+++ b/app/views/apartments/show.html.erb
@@ -2,6 +2,7 @@
   <li><a href="/apartments">Apartment List</a></li>
   <li><a href="/tenants">Tenant List</a></li>
   <li><a href="/apartments/<%= @apartment.id %>/tenants" >Tenants for this Apartment</a></li>
+  <li><a href="/apartments/<%= @apartment.id %>/edit" >Update this Apartment</a></li>
 
 </ul>
 <h1><%= @apartment.apt_name %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@ Rails.application.routes.draw do
   get '/', to: 'welcome#index'
   get '/apartments', to: 'apartments#index'
   get '/apartments/new', to: 'apartments#new'
-
+  
   get '/apartments/:id', to: 'apartments#show'
+  get '/apartments/:id/edit', to: 'apartments#edit'
+  patch '/apartments/:id', to: 'apartments#update'
   post '/apartments', to: 'apartments#create'
 
   get '/tenants', to: 'tenants#index'

--- a/spec/features/apartments/edit_spec.rb
+++ b/spec/features/apartments/edit_spec.rb
@@ -2,26 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'apartments edit page' do 
   describe 'as a visitor' do 
-    # before :each do 
-    #   @apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
-    #   @apartment_2 = Apartment.create!(apt_name: "Cruze Apartments", has_wd: true, unit_count: 50, city: "Denver", state: "CO", pet_friendly: true)
-    #   @apartment_3 = Apartment.create!(apt_name: "The Walter", has_wd: false, unit_count: 35, city: "Aurora", state: "CO", pet_friendly: false)
-    #   visit "/apartments/#{@apartment.id}/edit"
-    #   fill_in 'apartment[apt_name]', with: 'Haunted House'
-    #   choose 'wdno' 
-    #   fill_in 'apartment[unit_count]', with: 200
-    #   fill_in 'apartment[city]', with: 'Fear Town'
-    #   fill_in 'apartment[state]', with: 'CA' 
-    #   choose 'petyes'
-    #   click_button 'Submit'
-    # end
-
     describe 'edit form' do 
       it 'i see a form and can edit apartments attributes' do 
         apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
-
         visit "/apartments/#{apartment_1.id}/edit"
-
         expect(page).to have_content('Apartment Name:')
         expect(page).to have_content('Washer and Dryer In-Unit?')
         expect(page).to have_content('City:')
@@ -43,18 +27,14 @@ RSpec.describe 'apartments edit page' do
         click_button 'Submit'
       end
     
-
       it 'i can update apt info and click submit, i am taken back to the show page where the info is udpated' do 
         expect(current_path).to eq("/apartments/#{@apartment_1.id}")
       end 
 
       it 'i see the apartments updated info on the show page' do 
         visit "/apartments/#{@apartment_1.id}"
-        # save_and_open_page
-
         expect(page).to have_content("Total Units: 150")
       end
-
     end
   end
 end

--- a/spec/features/apartments/edit_spec.rb
+++ b/spec/features/apartments/edit_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper' 
+
+RSpec.describe 'apartments edit page' do 
+  describe 'as a visitor' do 
+    # before :each do 
+    #   @apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
+    #   @apartment_2 = Apartment.create!(apt_name: "Cruze Apartments", has_wd: true, unit_count: 50, city: "Denver", state: "CO", pet_friendly: true)
+    #   @apartment_3 = Apartment.create!(apt_name: "The Walter", has_wd: false, unit_count: 35, city: "Aurora", state: "CO", pet_friendly: false)
+    #   visit "/apartments/#{@apartment.id}/edit"
+    #   fill_in 'apartment[apt_name]', with: 'Haunted House'
+    #   choose 'wdno' 
+    #   fill_in 'apartment[unit_count]', with: 200
+    #   fill_in 'apartment[city]', with: 'Fear Town'
+    #   fill_in 'apartment[state]', with: 'CA' 
+    #   choose 'petyes'
+    #   click_button 'Submit'
+    # end
+
+    describe 'edit form' do 
+      it 'i see a form and can edit apartments attributes' do 
+        apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
+
+        visit "/apartments/#{apartment_1.id}/edit"
+
+        expect(page).to have_content('Apartment Name:')
+        expect(page).to have_content('Washer and Dryer In-Unit?')
+        expect(page).to have_content('City:')
+        expect(page).to have_content('State')
+        expect(page).to have_content('Pet Friendly?')
+      end 
+    end
+
+    describe 'when i click the link to update the apartment on its show page' do 
+      before :each do 
+        @apartment_1 = Apartment.create!(apt_name: "Riverview Apartments", has_wd: true, unit_count: 100, city: "Saint Paul", state: "MN", pet_friendly: true)
+        visit "/apartments/#{@apartment_1.id}/edit"
+        fill_in 'apartment[apt_name]', with: 'Riverview'
+        choose 'wdyes' 
+        fill_in 'apartment[unit_count]', with: 150
+        fill_in 'apartment[city]', with: 'Saint Paul'
+        fill_in 'apartment[state]', with: 'MN' 
+        choose 'petyes'
+        click_button 'Submit'
+      end
+    
+
+      it 'i can update apt info and click submit, i am taken back to the show page where the info is udpated' do 
+        expect(current_path).to eq("/apartments/#{@apartment_1.id}")
+      end 
+
+      it 'i see the apartments updated info on the show page' do 
+        visit "/apartments/#{@apartment_1.id}"
+        # save_and_open_page
+
+        expect(page).to have_content("Total Units: 150")
+      end
+
+    end
+  end
+end

--- a/spec/features/apartments/show_spec.rb
+++ b/spec/features/apartments/show_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe 'apartments show page', type: :feature do
         click_on('Tenants for this Apartment')
         expect(current_path).to eq("/apartments/#{@apartment_1.id}/tenants")
       end
+
+      it 'I see a link to update the apartment'
+      visit "/apartments/#{@apartment_1.id}"
+      click_on('Update this Apartment')
+      expect(current_path).to eq("/apartments/#{@apartment_1.id}/edit")
+
     end
 
 


### PR DESCRIPTION
Added a form to update an apartment's details.  A user can click on 'Update Apartment" and is taken to an edit page. On this page they can edit the apartment's details. After clicking submit, these details are saved and the user is taken back to the apartment's show page where they can see the updated info. 